### PR TITLE
日本語化実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem 'active_hash'
 gem 'payjp'
 
 gem "aws-sdk-s3", require: false
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.6)
       actionpack (= 6.0.3.6)
       activesupport (= 6.0.3.6)
@@ -329,6 +332,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,10 +19,10 @@ class Item < ApplicationRecord
   validates :name, length: { maximum: 40 }
   validates :description, length: { maximum: 1000 }
 
-  validates :price, presence: true, format: { with: /\A[0-9]+\z/, message: 'Half-width number' },
-                    numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'Out of setting range' }
+  validates :price, presence: true, format: { with: /\A[0-9]+\z/, message: "は数値で入力してください" },
+                    numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: "につきましては販売価格を参照ください" }
 
-  with_options presence: true, numericality: { other_than: 1, message: 'Select' } do
+  with_options presence: true, numericality: { other_than: 1, message: "を選択してください" } do
     validates :category_id
     validates :condition_id
     validates :burden_id

--- a/app/models/purchase_order.rb
+++ b/app/models/purchase_order.rb
@@ -10,12 +10,12 @@ class PurchaseOrder
     validates :item_id
     validates :token
     validates :area_id
-    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/ }
+    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "は(-)つきでお願いします" }
   end
 
-  validates :area_id, numericality: { other_than: 1, message: 'Select' }
+  validates :area_id, numericality: { other_than: 1, message: "を選択してください" }
 
-  validates :phone_number, format: { with: /\A[0-9]+\z/ }
+  validates :phone_number, format: { with: /\A[0-9]+\z/, message: "は半角数値で入力してください" }
   validates :phone_number, length: { maximum: 11 }
 
   def save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,17 +13,17 @@ class User < ApplicationRecord
     validates :first_name_kana
   end
 
-  with_options format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/, message: 'Full-width characters' } do
+  with_options format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/, message: "は全角で入力ください"} do
     validates :last_name
     validates :first_name
   end
 
-  with_options format: { with: /\A[ァ-ヶー－]+\z/, message: 'kana Full-width katakana characters' } do
+  with_options format: { with: /\A[ァ-ヶー－]+\z/, message: "は全角カナで入力ください" } do
     validates :last_name_kana
     validates :first_name_kana
   end
 
-  validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}+\z/i, message: 'Include both letters and numbers' }
+  validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}+\z/i, message: "は6文字以上の半角英数で入力ください" }
 
   has_many :items
   has_many :purchases

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima35237
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,29 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: 上の名前
+        first_name: 下の名前
+        last_name_kana: 上の名前のカナ
+        first_name_kana: 下の名前のカナ
+        birth_day: 生年月日 
+      item:
+        name: 商品名 
+        description: 商品の説明
+        image: 画像
+        price: 価格
+        category_id: カテゴリー
+        condition_id: 商品の状態
+        burden_id: 配送料の負担
+        area_id: 発送元の地域
+        day_id: 発送までの日数
+  activemodel:
+    attributes:
+      purchase_order:
+        post_code: 郵便番号
+        area_id: 都道府県
+        city: 市区町村
+        address: 番地
+        phone_number: 電話番号 
+        token: クレジットカード情報

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,115 +15,115 @@ RSpec.describe Item, type: :model do
       it '商品画像が空では保存できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "Image can't be blank"
+        expect(@item.errors.full_messages).to include "画像を入力してください"
       end
 
       it '商品名が空では保存できない' do
         @item.name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Name can't be blank"
+        expect(@item.errors.full_messages).to include "商品名を入力してください"
       end
 
       it '商品の説明が空では保存できない' do
         @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Description can't be blank"
+        expect(@item.errors.full_messages).to include "商品の説明を入力してください"
       end
 
       it 'カテゴリーが空では保存できない' do
         @item.category_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Category can't be blank"
+        expect(@item.errors.full_messages).to include "カテゴリーを入力してください"
       end
 
       it '商品の状態についての情報が空では保存できない' do
         @item.condition_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Condition can't be blank"
+        expect(@item.errors.full_messages).to include "商品の状態を入力してください"
       end
 
       it '配送料の負担についての情報が空では保存できない' do
         @item.burden_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Burden can't be blank"
+        expect(@item.errors.full_messages).to include "配送料の負担を入力してください"
       end
 
       it '発送元の地域の情報が空では保存できない' do
         @item.area_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Area can't be blank"
+        expect(@item.errors.full_messages).to include "発送元の地域を入力してください"
       end
 
       it '発送までの日数の情報が空では保存できない' do
         @item.day_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Day can't be blank"
+        expect(@item.errors.full_messages).to include "発送までの日数を入力してください"
       end
 
       it '販売価格の情報が空では保存できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price can't be blank"
+        expect(@item.errors.full_messages).to include "価格を入力してください"
       end
 
       it '販売価格は、¥0〜299の間の値段では保存できない' do
         @item.price = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price Out of setting range'
+        expect(@item.errors.full_messages).to include "価格につきましては販売価格を参照ください"
       end
 
       it '販売価格は、¥10,000,000以上の値段では保存できない' do
         @item.price = 10, 0o00, 0o00
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price Out of setting range'
+        expect(@item.errors.full_messages).to include "価格につきましては販売価格を参照ください"
       end
 
       it '販売価格は半角数字でないと保存できない' do
         @item.price = 'あいうえお'
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Price Out of setting range'
+        expect(@item.errors.full_messages).to include "価格につきましては販売価格を参照ください"
       end
 
       it 'active_hash、category_idのidが１のときは登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Category Select'
+        expect(@item.errors.full_messages).to include "カテゴリーを選択してください"
       end
 
       it 'active_hash、condition_idのidが１のときは登録できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Condition Select'
+        expect(@item.errors.full_messages).to include "商品の状態を選択してください"
       end
 
       it 'active_hash、burden_idのidが１のときは登録できない' do
         @item.burden_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Burden Select'
+        expect(@item.errors.full_messages).to include "配送料の負担を選択してください"
       end
 
       it 'active_hash、area_idのidが１のときは登録できない' do
         @item.area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Area Select'
+        expect(@item.errors.full_messages).to include "発送元の地域を選択してください"
       end
 
       it '商品名が４１文字以上では登録できない' do
         @item.name = 'a' * 41
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Name is too long (maximum is 40 characters)'
+        expect(@item.errors.full_messages).to include "商品名は40文字以内で入力してください"
       end
 
       it '商品説明が１００１文字以上では登録できない' do
         @item.description = 'a' * 1001
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Description is too long (maximum is 1000 characters)'
+        expect(@item.errors.full_messages).to include "商品の説明は1000文字以内で入力してください"
       end
 
       it 'userが紐付いていない場合は登録できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        expect(@item.errors.full_messages).to include "Userを入力してください"
       end
     end
   end

--- a/spec/models/purchase_order_spec.rb
+++ b/spec/models/purchase_order_spec.rb
@@ -23,62 +23,62 @@ RSpec.describe PurchaseOrder, type: :model do
       it 'post_codeが空だと保存できないこと' do
         @purchase_order.post_code = ''
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("Post code can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'post_codeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
         @purchase_order.post_code = '1234567'
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include('Post code is invalid')
+        expect(@purchase_order.errors.full_messages).to include("郵便番号は(-)つきでお願いします")
       end
       it 'active_hash、area_idのidが１のときは登録できない' do
         @purchase_order.area_id = 1
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include('Area Select')
+        expect(@purchase_order.errors.full_messages).to include("都道府県を選択してください")
       end
       it 'cityが空だと保存できないこと' do
         @purchase_order.city = ''
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("City can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("市区町村を入力してください")
       end
       it 'addressが空だと保存できないこと' do
         @purchase_order.address = ''
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("Address can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("番地を入力してください")
       end
       it 'phone_numberが空だと保存できないこと' do
         @purchase_order.phone_number = nil
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("Phone number can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'userが紐付いていないと保存できないこと' do
         @purchase_order.user_id = nil
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("User can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("Userを入力してください")
       end
       it 'itemが紐付いていないと保存できないこと' do
         @purchase_order.item_id = nil
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("Item can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("Itemを入力してください")
       end
       it 'tokenが空では登録できないこと' do
         @purchase_order.token = nil
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include("Token can't be blank")
+        expect(@purchase_order.errors.full_messages).to include("クレジットカード情報を入力してください")
       end
       it '電話番号は英数混合では登録できないこと' do
         @purchase_order.phone_number = '0901234123a'
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include('Phone number is invalid')
+        expect(@purchase_order.errors.full_messages).to include("電話番号は半角数値で入力してください")
       end
       it '電話番号は１１桁以内の数値でないと登録できないこと' do
         @purchase_order.phone_number = '0901234123a'
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include('Phone number is invalid')
+        expect(@purchase_order.errors.full_messages).to include("電話番号は半角数値で入力してください")
       end
       it '電話番号は１２桁以上では登録できないこと' do
         @purchase_order.phone_number = '090123412345'
         @purchase_order.valid?
-        expect(@purchase_order.errors.full_messages).to include('Phone number is too long (maximum is 11 characters)')
+        expect(@purchase_order.errors.full_messages).to include("電話番号は11文字以内で入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,26 +15,26 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Nickname can't be blank"
+        expect(@user.errors.full_messages).to include "ニックネームを入力してください"
       end
 
       it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email can't be blank"
+        expect(@user.errors.full_messages).to include "Eメールを入力してください"
       end
 
       it 'passwordが存在してもpassword_confirmationが空では登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include "パスワード（確認用）とパスワードの入力が一致しません"
       end
 
       it 'passwordが5文字以下では登録できない' do
         @user.password = '11aaa'
         @user.password_confirmation = '11aaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
+        expect(@user.errors.full_messages).to include "パスワードは6文字以上の半角英数で入力ください"
       end
 
       it '重複したemailが存在する場合登録できない' do
@@ -42,93 +42,93 @@ RSpec.describe User, type: :model do
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include "Eメールはすでに存在します"
       end
 
       it 'emailには「@」を含まないと登録ができない' do
         @user.email = 'tastcom'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Email is invalid'
+        expect(@user.errors.full_messages).to include "Eメールは不正な値です"
       end
 
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank"
+        expect(@user.errors.full_messages).to include "パスワードを入力してください"
       end
 
       it 'last_nameが空では登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name can't be blank"
+        expect(@user.errors.full_messages).to include "上の名前を入力してください"
       end
 
       it 'first_nameが空では登録できない ' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name can't be blank"
+        expect(@user.errors.full_messages).to include "下の名前を入力してください"
       end
 
       it 'パスワードが英語のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password Include both letters and numbers'
+        expect(@user.errors.full_messages).to include "パスワードは6文字以上の半角英数で入力ください"
       end
 
       it 'パスワードが数字のみでは登録できない' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
+        expect(@user.errors.full_messages).to include "パスワードは6文字以上の半角英数で入力ください"
       end
 
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana can't be blank"
+        expect(@user.errors.full_messages).to include "上の名前のカナを入力してください"
       end
 
       it 'first_name_kanaが空では登録できない ' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name kana can't be blank"
+        expect(@user.errors.full_messages).to include "下の名前のカナを入力してください"
       end
 
       it 'last_nameが全角漢字・平仮名・カタカナ以外では登録できない ' do
         @user.last_name = '/\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}+\z/i'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name Full-width characters'
+        expect(@user.errors.full_messages).to include "上の名前は全角で入力ください"
       end
 
       it 'first_nameが全角漢字・平仮名・カタカナ以外では登録できない ' do
         @user.first_name = '/\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}+\z/i'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name Full-width characters'
+        expect(@user.errors.full_messages).to include "下の名前は全角で入力ください"
       end
 
       it 'last_name_kanaが全角カタカナ以外では登録できない' do
         @user.last_name_kana = '/\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}+\z/i'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana kana Full-width katakana characters'
+        expect(@user.errors.full_messages).to include "上の名前のカナは全角カナで入力ください"
       end
 
       it 'first_name_kanaが全角カタカナ以外では登録できない ' do
         @user.first_name_kana = '/\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,}+\z/i'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana kana Full-width katakana characters'
+        expect(@user.errors.full_messages).to include "下の名前のカナは全角カナで入力ください"
       end
 
       it 'last_name_kanaがカタカナ以外の全角文字だと登録できないこと ' do
         @user.last_name_kana = '/\A[ぁ-んァ-ン一-龥]/'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name kana kana Full-width katakana characters'
+        expect(@user.errors.full_messages).to include "上の名前のカナは全角カナで入力ください"
       end
 
       it 'first_name_kanaがカタカナ以外の全角文字だと登録できないこと ' do
         @user.first_name_kana = '/\A[ぁ-んァ-ン一-龥]/'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name kana kana Full-width katakana characters'
+        expect(@user.errors.full_messages).to include "下の名前のカナは全角カナで入力ください"
       end
     end
   end


### PR DESCRIPTION
What
- rails-i18nを導入
- Itemモデルにmessageオプションを使用し、内容を明確にする
- purchase_orderモデルについても同上
- userモデルについても同上
- config/localesにそれぞれの日本語変換を記述
- すべてのテストコードを実施

Why
- エラーメッセージ日本語化実装のため